### PR TITLE
[SYM-3644] Constrain AWS Provider to < 5.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.0, < 5.0"
     }
   }
 }


### PR DESCRIPTION
# Summary
- The version of the s3_bucket module being used is not compatible with AWS Provider 5.x
- This PR adds a constraint of `< 5.0` to the AWS provider defined in `versions.tf`
