### PR TITLE
[SYM-3644] Support AWS Provider 5.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ data "aws_caller_identity" "current" {}
 
 module "s3_bucket" {
   source  = "cloudposse/s3-bucket/aws"
-  version = "0.44.0"
+  version = "3.1.2"
 
   acl                = "private"
   enabled            = true # Create resources

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0, < 5.0"
+      version = ">= 4.9.0"
     }
   }
 }


### PR DESCRIPTION
# Summary
- Supports AWS Provider 5.x by bumping the `s3_bucket` module version to the most recent (`3.1.2`)
- Updates the AWS Provider constraints to `>= 4.9.0`, to match the constraints required by the `s3_bucket` module.


# Testing
- Applied the module with the configuration from `main`
- Updated the constraints and module, ran `terraform init -upgrade && terraform apply`. Confirmed that the new configuration applies cleanly with no additional user action.

![Screenshot 2023-06-05 at 10 14 13 AM](https://github.com/symopsio/terraform-aws-kinesis-firehose-connector/assets/10479740/cd7126e6-6375-43cb-bd42-c57679477d6b)

![Screenshot 2023-06-05 at 10 20 25 AM](https://github.com/symopsio/terraform-aws-kinesis-firehose-connector/assets/10479740/0a58ef8e-3775-43fe-ba28-d55f2e376af6)

