### PR TITLE
Add symopsio/eng as a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Auto-request the eng team for all opened PRs
+*       @symopsio/eng


### PR DESCRIPTION
# Summary
- Adds a `CODEOWNERS` file with `symopsio/eng`, to auto-request the eng team when PRs are opened
